### PR TITLE
Add separate time estimate multipliers for new cards and reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@
 <ul>
   <li><b>Show daily progress bar in deck overview</b></li>
   <li><b>Show daily progress bar in review screen</b></li>
-  <li><b>Time estimate multiplier</b> — only affects displayed time estimates.</li>
+  <li><b>Time estimate multiplier (new cards)</b> — used during NEW phase only.</li>
+  <li><b>Time estimate multiplier (reviews)</b> — used during REVIEW phase only.</li>
 </ul>
 
 <p><b>Premium visuals (Premium):</b></p>

--- a/config.py
+++ b/config.py
@@ -126,7 +126,17 @@ class DeadlineDb:
         self.db.setdefault("show_review_progress", True)
         # Celebration (rainbow) when hitting 100% in reviewer
         self.db.setdefault("show_celebration", True)
-        self.db.setdefault("time_multiplier", 1.0)
+
+        # Time estimates: keep legacy key, but store separate multipliers per phase.
+        try:
+            legacy_mult = float(self.db.get("time_multiplier", 1.0) or 1.0)
+        except Exception:
+            legacy_mult = 1.0
+        legacy_mult = max(0.1, min(legacy_mult, 10.0))
+
+        self.db.setdefault("time_multiplier", legacy_mult)
+        self.db.setdefault("time_multiplier_new", legacy_mult)
+        self.db.setdefault("time_multiplier_review", legacy_mult)
 
         # Shared progress fill style for both bars
         self.db.setdefault(
@@ -201,19 +211,58 @@ class DeadlineDb:
 
     @property
     def time_multiplier(self) -> float:
+        # Backwards compatibility alias.
         try:
-            v = float(self.db.get("time_multiplier", 1.0) or 1.0)
+            v = float(self.db.get("time_multiplier_review", self.db.get("time_multiplier", 1.0)) or 1.0)
         except Exception:
             v = 1.0
         return max(0.1, min(v, 10.0))
 
     @time_multiplier.setter
     def time_multiplier(self, v: float) -> None:
+        # Backwards compatibility alias.
         try:
             vf = float(v)
         except Exception:
             vf = 1.0
-        self.db["time_multiplier"] = max(0.1, min(vf, 10.0))
+        clamped = max(0.1, min(vf, 10.0))
+        self.db["time_multiplier"] = clamped
+        self.db["time_multiplier_review"] = clamped
+
+    @property
+    def time_multiplier_new(self) -> float:
+        try:
+            v = float(self.db.get("time_multiplier_new", self.db.get("time_multiplier", 1.0)) or 1.0)
+        except Exception:
+            v = 1.0
+        return max(0.1, min(v, 10.0))
+
+    @time_multiplier_new.setter
+    def time_multiplier_new(self, v: float) -> None:
+        try:
+            vf = float(v)
+        except Exception:
+            vf = 1.0
+        self.db["time_multiplier_new"] = max(0.1, min(vf, 10.0))
+
+    @property
+    def time_multiplier_review(self) -> float:
+        try:
+            v = float(self.db.get("time_multiplier_review", self.db.get("time_multiplier", 1.0)) or 1.0)
+        except Exception:
+            v = 1.0
+        return max(0.1, min(v, 10.0))
+
+    @time_multiplier_review.setter
+    def time_multiplier_review(self, v: float) -> None:
+        try:
+            vf = float(v)
+        except Exception:
+            vf = 1.0
+        clamped = max(0.1, min(vf, 10.0))
+        self.db["time_multiplier_review"] = clamped
+        # Keep legacy key in sync for older code paths.
+        self.db["time_multiplier"] = clamped
     
     @property
     def is_premium(self) -> bool:

--- a/deck_browser_ui.py
+++ b/deck_browser_ui.py
@@ -214,7 +214,12 @@ def _render_card(
     time_html = ""
     if bool(getattr(dl, "hasEstimate", False)) and (not bool(getattr(dl, "hide_target", False))):
         hours_per_day = float(getattr(dl, "todoTime", 0.0) or 0.0)
-        mult = float(getattr(db, "time_multiplier", 1.0) or 1.0)
+        is_new_phase = bool(getattr(dl, "new", 0) or 0) > 0
+        mult = float(
+            getattr(db, "time_multiplier_new", 1.0)
+            if is_new_phase
+            else getattr(db, "time_multiplier_review", 1.0)
+        )
 
         mins = int(round(hours_per_day * 60.0 * mult))
         if mins > 0:
@@ -226,10 +231,11 @@ def _render_card(
             else:
                 t = f"{m}m"
 
+            phase_txt = "new cards" if is_new_phase else "reviews"
             tooltip = (
                 "Estimated time needed per day.\n"
                 "Based on your recent average review speed in this deck.\n"
-                f"Multiplier: {mult:.2f}×"
+                f"Phase: {phase_txt}. Multiplier: {mult:.2f}×"
             )
 
             time_html = (
@@ -664,7 +670,12 @@ def display_footer(deck_browser, content) -> None:
         mins_today_est = 0
         if bool(getattr(dl, "hasEstimate", False)) and (not bool(getattr(dl, "hide_target", False))):
             hours_per_day = float(getattr(dl, "todoTime", 0.0) or 0.0)
-            mult = float(getattr(db, "time_multiplier", 1.0) or 1.0)
+            is_new_phase = bool(getattr(dl, "new", 0) or 0) > 0
+            mult = float(
+                getattr(db, "time_multiplier_new", 1.0)
+                if is_new_phase
+                else getattr(db, "time_multiplier_review", 1.0)
+            )
             mins_today_est = int(round(hours_per_day * 60.0 * mult))
             if mins_today_est < 0:
                 mins_today_est = 0

--- a/settings.py
+++ b/settings.py
@@ -556,15 +556,25 @@ class DeadlinerDialog(QDialog):
         self.reviewProgressCheckbox = _bool_box(getattr(self.db, "show_review_progress", True))
         basic_form.addRow("Show daily progress bar in review screen:", self.reviewProgressCheckbox)
     
-        self.timeMultiplierSpin = MultiplierSpinBox()
-        self.timeMultiplierSpin.setMultiplier(float(getattr(self.db, "time_multiplier", 1.0) or 1.0))
-        self.timeMultiplierSpin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self.timeMultiplierSpin.setToolTip(
-            "Scales the time estimate shown in progress bars.\n"
-            "Example: 2.00× means time is shown as double."
+        self.timeMultiplierNewSpin = MultiplierSpinBox()
+        self.timeMultiplierNewSpin.setMultiplier(float(getattr(self.db, "time_multiplier_new", 1.0) or 1.0))
+        self.timeMultiplierNewSpin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.timeMultiplierNewSpin.setToolTip(
+            "Scales the time estimate shown in progress bars during NEW phase.\n"
+            "Example: 0.80× means time is shown 20% lower."
         )
-        self.timeMultiplierSpin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
-        basic_form.addRow("Time estimate multiplier:", self.timeMultiplierSpin)
+        self.timeMultiplierNewSpin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        basic_form.addRow("Time estimate multiplier (new cards):", self.timeMultiplierNewSpin)
+
+        self.timeMultiplierReviewSpin = MultiplierSpinBox()
+        self.timeMultiplierReviewSpin.setMultiplier(float(getattr(self.db, "time_multiplier_review", 1.0) or 1.0))
+        self.timeMultiplierReviewSpin.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.timeMultiplierReviewSpin.setToolTip(
+            "Scales the time estimate shown in progress bars during REVIEW phase.\n"
+            "Example: 1.20× means time is shown 20% higher."
+        )
+        self.timeMultiplierReviewSpin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        basic_form.addRow("Time estimate multiplier (reviews):", self.timeMultiplierReviewSpin)
     
         outer.addWidget(basicGroup)
     
@@ -1248,8 +1258,11 @@ class DeadlinerDialog(QDialog):
                 }
 
     
-            if getattr(self, "timeMultiplierSpin", None):
-                self.db.time_multiplier = float(self.timeMultiplierSpin.multiplier())
+            if getattr(self, "timeMultiplierNewSpin", None):
+                self.db.time_multiplier_new = float(self.timeMultiplierNewSpin.multiplier())
+
+            if getattr(self, "timeMultiplierReviewSpin", None):
+                self.db.time_multiplier_review = float(self.timeMultiplierReviewSpin.multiplier())
     
             # --- If NOT global mode → save per-deck deadline ---
             if not self._global_mode:


### PR DESCRIPTION
### Motivation
- Users requested two separate time multipliers because NEW (young) cards are typically faster than REVIEWs and should have a different displayed time estimate. 
- Provide a backward-compatible way to introduce per-phase multipliers without breaking existing configs or UI.

### Description
- Add two new config keys `time_multiplier_new` and `time_multiplier_review` and initialize them from the legacy `time_multiplier` value to migrate existing users; keep `time_multiplier` as a compatibility alias synchronized with the review multiplier (`config.py`).
- Expose two spinner controls in the Feedback tab: `Time estimate multiplier (new cards)` and `Time estimate multiplier (reviews)`, and persist their values to the new config keys (`settings.py`).
- Use the appropriate multiplier when rendering time estimates and when computing the sortable `mins_today_est` in the deck overview UI by selecting the NEW multiplier if the deck is in the new/learning phase and the REVIEW multiplier otherwise (`deck_browser_ui.py`).
- Update README to document the two separate time-estimate settings.

### Testing
- Ran static/compile check: `python -m py_compile config.py settings.py deck_browser_ui.py models.py helpers.py`, which succeeded. 
- Verified that new multipliers default to the legacy `time_multiplier` value so existing users see no behavior change by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b868863b083229f60463d72498b90)