### PR TITLE
Align changelog dialog with final v1.1 content and normalize changelog.py CRLF

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,9 @@
 <h3>Deckline v1.1</h3>
 <h4>(2026-02-22)</h4>
 <ul>
-  <li>🔥 <b>Streaks toegevoegd</b> — Deckline kan nu je dagelijkse target-streak tonen, zodat je in één oogopslag ziet of je je ritme volhoudt. Dit maakt dagelijkse voortgang motiverender en duidelijker zonder extra schermen.</li>
-  <li>⏱️ <b>Time multiplier opgesplitst</b> — de tijdsinschatting gebruikt nu aparte multipliers voor <b>new</b> en <b>reviews</b>. Daardoor sluit de geschatte studietijd beter aan op je echte workload per fase.</li>
+  <li>🔥 <b>Streaks added</b> — Deckline now shows your daily target streak so you can see at a glance whether you're maintaining momentum, making daily progress clearer and more motivating without extra screens.</li>
+  <li>⏱️ <b>Time multiplier split</b> — time estimates now use separate multipliers for <b>new</b> and <b>reviews</b>, improving study-time accuracy per phase.</li>
+  <li>🆓 <b>Free core access expanded</b> — free users can now create up to <b>3 deadlines</b> to use more of Deckline's core functionality before upgrading.</li>
 </ul>
 <hr>
 

--- a/changelog.py
+++ b/changelog.py
@@ -1,6 +1,5 @@
-# changelog.py
 from __future__ import annotations
-
+from pathlib import Path
 from aqt import mw
 from aqt.qt import (
     QDialog,
@@ -137,6 +136,8 @@ class DecklineChangelogDialog(QDialog):
             "}"
         )
 
+        streak_img = (Path(__file__).resolve().parent / "deckline_streaks.png").as_uri()
+
         # Feel free to tweak text here later.
         html = f"""
         <div style="font-size:12.5px; line-height:1.45;">
@@ -145,56 +146,30 @@ class DecklineChangelogDialog(QDialog):
             In this update we focus on two concrete improvements: streaks and a more accurate time estimate flow.
           </p>
           
-          <h3 style="margin:14px 0 6px 0;">🔥 Streaks added</h3>
+          <h3 style="margin:14px 0 6px 0;">🆓 Free core access expanded</h3>
           <ul style="margin:6px 0 0 18px;">
-            <li>Deckline now highlights your daily target streak so you can quickly see if you're maintaining momentum day after day.</li>
-            <li>This keeps your daily consistency visible at a glance and adds a simple extra motivation loop while studying.</li>
+            <li>Free users can now create up to <b>3 deadlines</b> before hitting the premium cap.</li>
+            <li>This opens up more of Deckline's core planning workflow in the free version.</li>
           </ul>
 
+          <h3 style="margin:14px 0 6px 0;">🔥 Streaks added (premium users)</h3>
+          <ul style="margin:6px 0 0 18px;">
+            <li>Deckline now highlights your daily target streak so you can quickly see if you're maintaining momentum day after day.</li>
+            <li>The streak improves when you meet your daily review goal.</li>
+            <li>This keeps your daily consistency visible at a glance and adds a simple extra motivation loop while studying.</li>
+          </ul>
+          
+          <div style="margin:10px 0 12px 0; padding:10px; border-radius:12px;">
+            <img src="{streak_img}"
+                 alt="Deckline streaks"
+                 style="width:100%; max-width:620px; border-radius:10px; display:block; margin:0 auto;" />
+          </div>
 
-          <h3 style="margin:14px 0 6px 0;">⏱️ Time multiplier split (New vs Reviews)</h3>
+
+          <h3 style="margin:14px 0 6px 0;">⏱️ Time multiplier split (New vs Reviews) (Idea from zitrone420 on Github)</h3>
           <ul style="margin:6px 0 0 18px;">
             <li>The time estimate now uses separate multipliers for <b>new cards</b> and <b>reviews</b>, instead of one shared value.</li>
             <li>Because each phase has different pacing, this gives a more realistic estimate of today's required study time.</li>
-          </ul>
-
-
-          <h3 style="margin:14px 0 6px 0;">✅ Deck Browser cards + topbar (v1.0 foundation)</h3>
-          <ul style="margin:6px 0 0 18px;">
-            <li><b>Modern card layout</b> — easier to scan at a glance.</li>
-            <li><b>Cleaner badges</b> like <span style="color:#22C55E;"><b>ON TRACK</b></span>,
-                <span style="color:#EF4444;"><b>BEHIND</b></span>, <span style="color:#3B82F6;"><b>PENDING</b></span>.</li>
-            <li><b>Focus + Sort controls</b> in the new topbar to instantly find what matters.</li>
-          </ul>
-
-          <h3 style="margin:14px 0 6px 0;">✨ UI improvements everywhere</h3>
-          <ul style="margin:6px 0 0 18px;">
-            <li>Smoother spacing, better typography, and consistent styling.</li>
-            <li>Tooltips explain <b>Phase 1 (NEW)</b> vs <b>Phase 2 (REVIEW)</b> more clearly.</li>
-            <li>Deck icons + accent colors are more consistent and readable.</li>
-          </ul>
-
-          <h3 style="margin:14px 0 6px 0;">📈 Premium: Stats dashboard (7-day view)</h3>
-          <ul style="margin:6px 0 0 18px;">
-            <li>New <b>Deckline Stats</b> window: last 7 days, per deck, done vs target.</li>
-            <li>Instant green/red feedback: above/below target.</li>
-            <li>Also supports <b>All deadlines (sum)</b> to see your total momentum.</li>
-          </ul>
-
-          <h3 style="margin:14px 0 6px 0;">💎 Premium: More motivation + control</h3>
-          <ul style="margin:6px 0 0 18px;">
-            <li><b>Unlimited deadlines</b> (no cap).</li>
-            <li><b>Vacation days</b>: add days off and Deckline adjusts your daily target automatically.</li>
-            <li><b>Custom progress colors</b>: auto / solid / gradient.</li>
-            <li><b>Celebration animation</b> when you hit 100% for the first time that day.</li>
-          </ul>
-
-          <h3 style="margin:14px 0 6px 0;">🧠 Small but important behavior changes</h3>
-          <ul style="margin:6px 0 0 18px;">
-            <li>Targets stay stable during the day (less “moving goalpost” feeling).</li>
-            <li>Better handling of parent decks: the progress bars follow the nearest enabled deadline deck.</li>
-            <li>Cleaner “rest day” behavior for skipped days (weekends/vacations).</li>
-            <li>You can access the deadline settings by clicking the **icon on the left side of a Deckline card** in the Deck Browser.</li>
           </ul>
 
           <div style="margin-top:14px; padding:12px; border-radius:12px;
@@ -213,21 +188,13 @@ class DecklineChangelogDialog(QDialog):
         # -------------------------
         footer = QHBoxLayout()
         footer.setSpacing(10)
-
+        
         self.dontShowAgain = QCheckBox("Don’t show this again")
-        self.dontShowAgain.setChecked(True)  # default: once per version
+        self.dontShowAgain.setChecked(True)
         footer.addWidget(self.dontShowAgain, 0)
-
+        
         footer.addStretch(1)
-
-        btnSettings = QPushButton("Open settings")
-        btnSettings.setCursor(Qt.CursorShape.PointingHandCursor)
-        btnSettings.clicked.connect(_open_settings_global)
-
-        btnStats = QPushButton("Open Stats")
-        btnStats.setCursor(Qt.CursorShape.PointingHandCursor)
-        btnStats.clicked.connect(_open_stats)
-
+        
         btnPremium = QPushButton("Upgrade to Premium")
         btnPremium.setCursor(Qt.CursorShape.PointingHandCursor)
         btnPremium.setStyleSheet(
@@ -236,10 +203,9 @@ class DecklineChangelogDialog(QDialog):
             "QPushButton:hover { background: rgba(255, 63, 152, 0.98); }"
         )
         btnPremium.clicked.connect(_open_kofi)
-
-        footer.addWidget(btnSettings, 0)
-        footer.addWidget(btnStats, 0)
+        
         footer.addWidget(btnPremium, 0)
+
 
         root.addLayout(footer)
 

--- a/models.py
+++ b/models.py
@@ -66,7 +66,7 @@ class DeadlineDeck:
         is_new = self.deck_key not in db.deadlines
 
         if is_new and not db.is_premium:
-            if len(db.deadlines) >= 2:
+            if len(db.deadlines) >= 3:
                 from aqt.qt import QMessageBox
                 from aqt import mw
                 import webbrowser
@@ -76,7 +76,7 @@ class DeadlineDeck:
                 msg.setIcon(QMessageBox.Icon.Information)
             
                 msg.setText(
-                    "You can only create 2 deadlines in the free version.\n\n"
+                    "You can only create 3 deadlines in the free version.\n\n"
                     "Upgrade to support development of Deckline and to unlock unlimited deadlines."
                 )
             

--- a/settings.py
+++ b/settings.py
@@ -836,6 +836,9 @@ class DeadlinerDialog(QDialog):
     
         unlockBtn = QPushButton("Unlock")
         unlockBtn.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        resetFreeBtn = QPushButton("Reset naar Free test")
+        resetFreeBtn.setCursor(Qt.CursorShape.PointingHandCursor)
     
         def _refresh_status() -> None:
             self.premiumStatusLabel.setText(
@@ -856,9 +859,18 @@ class DeadlinerDialog(QDialog):
             else:
                 showInfo("Invalid code.\n\nCheck your Ko-fi message and try again.")
     
+        def _reset_to_free_test() -> None:
+            self.db.is_premium = False
+            self.db.save()
+            refreshDeadliner()
+            _refresh_status()
+            showInfo("Premium reset to free test mode.")
+
         unlockBtn.clicked.connect(_unlock)
-    
+        resetFreeBtn.clicked.connect(_reset_to_free_test)
+
         btnRowL.addWidget(unlockBtn, 0)
+        btnRowL.addWidget(resetFreeBtn, 0)
         btnRowL.addStretch(1)
     
         form.addRow("", btnRow)


### PR DESCRIPTION
### Motivation
- Make the in-app changelog match the final approved v1.1 content (text, sections and streak image) so it can be merged as the release announcement. 
- Ensure `changelog.py` uses CRLF line endings to avoid Windows copy/paste issues and preserve repository newline style.

### Description
- Rewrote the `DecklineChangelogDialog` body in `changelog.py` to match the final v1.1 changelog text and ordering, added the streak image via `deckline_streaks.png`, and simplified footer actions to keep the "Don’t show this again" checkbox and the "Upgrade to Premium" button. 
- Added `Path` import and used `Path(...).as_uri()` to embed the streak image in the dialog HTML. 
- Saved `changelog.py` with CRLF line endings to remove lone LF occurrences. 
- (Related observed changes) updated free-deadline limit text/logic in `models.py` from 2→3 where applicable and adjusted settings UI text/buttons in `settings.py` in prior rollouts that are present in the diff. 

### Testing
- Ran `python -m py_compile changelog.py` which completed successfully. 
- Verified newline format with a small Python check that reported CRLF counts and zero lone LF in `changelog.py`. 
- Removed `__pycache__`, added and committed the updated `changelog.py` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c338c95648322b4971e2cd01e030d)