### PR TITLE
Keep active streak visible during current day

### DIFF
--- a/core_mod/helpers.py
+++ b/core_mod/helpers.py
@@ -849,6 +849,8 @@ def calculate_current_streak(entries: list[dict]) -> int:
     - Only days with target > 0 count as "streak days".
     - If target == 0 (rest/skip day, pending), the streak is frozen (does not increase, does not break).
     - If a day with target > 0 exists and done < target, streak breaks.
+    - Exception: today's unfinished study day does not immediately break the
+      visible streak; we keep showing the previous streak until tomorrow.
     - If a date is missing from the log, we break (we can't know if it was a skip/vacation day).
     """
     if not entries:
@@ -899,6 +901,13 @@ def calculate_current_streak(entries: list[dict]) -> int:
         # study day: must meet target
         if done >= target:
             streak += 1
+            cur = cur - timedelta(days=1)
+            continue
+
+        # Keep current streak visible during today's unfinished target.
+        # If the target remains unmet, this same log row will be "yesterday"
+        # tomorrow and then break the streak as normal.
+        if cur == today:
             cur = cur - timedelta(days=1)
             continue
 


### PR DESCRIPTION
### Motivation
- Users lost their visible streak at the start of a new day before they had the chance to hit that day's target, reducing motivation.
- The streak should still break if a past (non-today) day with a positive target was missed, so that behavior must be preserved.

### Description
- Update `calculate_current_streak` in `core_mod/helpers.py` to treat an unfinished `today` as non-fatal for the visible streak by skipping the break when `cur == today` and `done < target`.
- Add a docstring note explaining the exception for today's unfinished study day while retaining the existing rules for rest days and missing dates.

### Testing
- Ran `python -m compileall core_mod/helpers.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4013a50e88322bd9bc07a9aaaafa9)